### PR TITLE
Many miscellaneous fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ DEBUG_MODE_INCLUDE_DELTA=false
   - higher if Billy doesn't respond (because he thinks you're still talking)
 - `DEBUG_MODE`: Print debug information such as OpenAI responses to the output stream.
 - `DEBUG_MODE_INCLUDE_DELTA`: Also print voice and speech delta data, which can get very noisy.
-
+- `ALLOW_UPDATE_PERSONALITY_INI`: If true, personality updates asked for by the user will be written and committed to the personality file. If false, changes to personality will only affect the current running process.
 ---
 
 ## 8. Systemd Service (for auto-boot)

--- a/README.md
+++ b/README.md
@@ -158,6 +158,9 @@ MQTT_PASSWORD=password
 ## optional overwrites
 MIC_TIMEOUT_SECONDS=5
 SILENCE_THRESHOLD=900
+
+DEBUG_MODE=true
+DEBUG_MODE_INCLUDE_DELTA=false
 ```
 
 ### Explanation of fields
@@ -169,6 +172,8 @@ SILENCE_THRESHOLD=900
 - `SILENCE_THRESHOLD`: Audio threshold (RMS) for what counts as mic input
   - lower this value if Billy interrupts you too quickly
   - higher if Billy doesn't respond (because he thinks you're still talking)
+- `DEBUG_MODE`: Print debug information such as OpenAI responses to the output stream.
+- `DEBUG_MODE_INCLUDE_DELTA`: Also print voice and speech delta data, which can get very noisy.
 
 ---
 

--- a/billy-b-assistant/core/audio.py
+++ b/billy-b-assistant/core/audio.py
@@ -12,20 +12,21 @@ from queue import Queue
 
 import numpy as np
 import sounddevice as sd
-from core.config import (
+from scipy.signal import resample
+
+from .config import (
     CHUNK_MS,
     MIC_PREFERENCE,
     PLAYBACK_VOLUME,
     SPEAKER_PREFERENCE,
     TEXT_ONLY_MODE,
 )
-from core.movements import (
+from .movements import (
     flap_from_pcm_chunk,
     interlude,
     move_head,
     move_tail_async,
 )
-from scipy.signal import resample
 
 
 # === Audio Device Globals ===

--- a/billy-b-assistant/core/audio.py
+++ b/billy-b-assistant/core/audio.py
@@ -273,15 +273,21 @@ def send_mic_audio(ws, samples, loop):
         .astype(np.int16)
         .tobytes()
     )
-    asyncio.run_coroutine_threadsafe(
-        ws.send(
-            json.dumps({
-                "type": "input_audio_buffer.append",
-                "audio": base64.b64encode(pcm).decode("utf-8"),
-            })
-        ),
-        loop,
-    )
+    try:
+        future = asyncio.run_coroutine_threadsafe(
+            ws.send(
+                json.dumps({
+                    "type": "input_audio_buffer.append",
+                    "audio": base64.b64encode(pcm).decode("utf-8"),
+                })
+            ),
+            loop,
+        )
+
+        # Await the result; avoid race conditions.
+        future.result()
+    except Exception as e:
+        print(f"❌ Failed to send audio chunk: {e}")
 
 
 def enqueue_wav_to_playback(filepath):

--- a/billy-b-assistant/core/audio.py
+++ b/billy-b-assistant/core/audio.py
@@ -314,8 +314,19 @@ def play_random_wake_up_clip():
     if not clips:
         print("⚠️ No wake-up clips found.")
         return None
+
     clip = random.choice(clips)
+
+    # Track how many tasks were pending before enqueue
+    already_pending = playback_queue.unfinished_tasks
+
+    # Enqueue the WAV file
     enqueue_wav_to_playback(clip)
+
+    # Wait for exactly those new chunks to finish
+    while playback_queue.unfinished_tasks > already_pending:
+        time.sleep(0.01)
+
     return clip
 
 

--- a/billy-b-assistant/core/audio.py
+++ b/billy-b-assistant/core/audio.py
@@ -1,21 +1,32 @@
-import sounddevice as sd
-import numpy as np
-from scipy.signal import resample
-from queue import Queue
-import wave
-import threading
-import sys
-import time
-import glob
-import os
 import asyncio
-import json
 import base64
+import glob
+import json
+import os
 import random
-import contextlib
+import sys
+import threading
+import time
+import wave
+from queue import Queue
 
-from core.config import CHUNK_MS, TEXT_ONLY_MODE, DEBUG_MODE, MIC_PREFERENCE, SPEAKER_PREFERENCE, PLAYBACK_VOLUME, BACKSTORY
-from core.movements import flap_from_pcm_chunk, move_head, head_out, interlude, move_tail_async
+import numpy as np
+import sounddevice as sd
+from core.config import (
+    CHUNK_MS,
+    MIC_PREFERENCE,
+    PLAYBACK_VOLUME,
+    SPEAKER_PREFERENCE,
+    TEXT_ONLY_MODE,
+)
+from core.movements import (
+    flap_from_pcm_chunk,
+    interlude,
+    move_head,
+    move_tail_async,
+)
+from scipy.signal import resample
+
 
 # === Audio Device Globals ===
 MIC_DEVICE_INDEX = None
@@ -38,6 +49,7 @@ song_mode = False
 beat_length = 0.5
 compensate_tail_beats = 0.0
 
+
 def detect_devices(debug=False):
     global MIC_DEVICE_INDEX, MIC_RATE, MIC_CHANNELS, CHUNK_SIZE
     global OUTPUT_DEVICE_INDEX, OUTPUT_RATE, OUTPUT_CHANNELS
@@ -46,12 +58,16 @@ def detect_devices(debug=False):
 
     for i, d in enumerate(devices):
         if debug:
-            print(f"{i}: {d['name']} (inputs: {d['max_input_channels']}, outputs: {d['max_output_channels']})")
+            print(
+                f"{i}: {d['name']} (inputs: {d['max_input_channels']}, outputs: {d['max_output_channels']})"
+            )
 
         if MIC_DEVICE_INDEX is None and d['max_input_channels'] > 0:
-            if MIC_PREFERENCE and MIC_PREFERENCE.lower() in d['name'].lower():
-                MIC_DEVICE_INDEX = i
-            elif not MIC_PREFERENCE:
+            if (
+                MIC_PREFERENCE
+                and MIC_PREFERENCE.lower() in d['name'].lower()
+                or not MIC_PREFERENCE
+            ):
                 MIC_DEVICE_INDEX = i
 
             MIC_RATE = int(d['default_samplerate'])
@@ -59,9 +75,11 @@ def detect_devices(debug=False):
             CHUNK_SIZE = int(MIC_RATE * CHUNK_MS / 1000)
 
         if OUTPUT_DEVICE_INDEX is None and d['max_output_channels'] > 0:
-            if SPEAKER_PREFERENCE and SPEAKER_PREFERENCE.lower() in d['name'].lower():
-                OUTPUT_DEVICE_INDEX = i
-            elif not SPEAKER_PREFERENCE:
+            if (
+                SPEAKER_PREFERENCE
+                and SPEAKER_PREFERENCE.lower() in d['name'].lower()
+                or not SPEAKER_PREFERENCE
+            ):
                 OUTPUT_DEVICE_INDEX = i
 
             OUTPUT_RATE = int(d['default_samplerate'])
@@ -70,6 +88,7 @@ def detect_devices(debug=False):
     if MIC_DEVICE_INDEX is None or (OUTPUT_DEVICE_INDEX is None and not TEXT_ONLY_MODE):
         print("❌ No suitable input/output devices found.")
         sys.exit(1)
+
 
 def playback_worker(chunk_ms):
     global last_played_time
@@ -87,10 +106,7 @@ def playback_worker(chunk_ms):
 
     try:
         with sd.OutputStream(
-            samplerate=48000,
-            channels=2,
-            dtype='int16',
-            device=OUTPUT_DEVICE_INDEX
+            samplerate=48000, channels=2, dtype='int16', device=OUTPUT_DEVICE_INDEX
         ) as stream:
             print("🔈 Output stream opened")
             while True:
@@ -122,16 +138,20 @@ def playback_worker(chunk_ms):
                     if mode == "song":
                         audio_chunk, flap_chunk, rms_drums = item[1], item[2], item[3]
 
-                        flap_from_pcm_chunk(np.frombuffer(flap_chunk, dtype=np.int16), chunk_ms=chunk_ms)
+                        flap_from_pcm_chunk(
+                            np.frombuffer(flap_chunk, dtype=np.int16), chunk_ms=chunk_ms
+                        )
 
                         if rms_drums > drums_peak:
-                                drums_peak = rms_drums
-                                drums_peak_time = now
+                            drums_peak = rms_drums
+                            drums_peak_time = now
 
-                        adjusted_now = (now - song_start_time) + (compensate_tail_beats * beat_length)
+                        adjusted_now = (now - song_start_time) + (
+                            compensate_tail_beats * beat_length
+                        )
                         elapsed_song_time = now - song_start_time
 
-                        #print(f"[DEBUG] ⏱ elapsed: {elapsed_song_time:.2f}s | 🥁 adjusted: {adjusted_now:.2f}s | 🎯 next beat at {next_beat_time:.2f}s | 🐟 head_move_queue: {list(head_move_queue.queue)}")
+                        # print(f"[DEBUG] ⏱ elapsed: {elapsed_song_time:.2f}s | 🥁 adjusted: {adjusted_now:.2f}s | 🎯 next beat at {next_beat_time:.2f}s | 🐟 head_move_queue: {list(head_move_queue.queue)}")
 
                         if adjusted_now >= next_beat_time:
                             if drums_peak > 1500 and not head_out:
@@ -141,9 +161,13 @@ def playback_worker(chunk_ms):
                             next_beat_time += beat_length
 
                         mono = np.frombuffer(audio_chunk, dtype=np.int16)
-                        resampled = resample(mono, int(len(mono) * 48000 / 24000)).astype(np.int16)
+                        resampled = resample(
+                            mono, int(len(mono) * 48000 / 24000)
+                        ).astype(np.int16)
                         stereo = np.repeat(resampled[:, np.newaxis], 2, axis=1)
-                        stereo = np.clip(stereo * PLAYBACK_VOLUME, -32768, 32767).astype(np.int16)
+                        stereo = np.clip(
+                            stereo * PLAYBACK_VOLUME, -32768, 32767
+                        ).astype(np.int16)
                         stream.write(stereo)
 
                     elif mode == "tts":
@@ -151,13 +175,17 @@ def playback_worker(chunk_ms):
                         mono = np.frombuffer(chunk, dtype=np.int16)
                         chunk_len = int(24000 * chunk_ms / 1000)
                         for i in range(0, len(mono), chunk_len):
-                            sub = mono[i:i+chunk_len]
+                            sub = mono[i : i + chunk_len]
                             if len(sub) == 0:
                                 continue
                             flap_from_pcm_chunk(sub, chunk_ms=chunk_ms)
-                            resampled = resample(sub, int(len(sub) * 48000 / 24000)).astype(np.int16)
+                            resampled = resample(
+                                sub, int(len(sub) * 48000 / 24000)
+                            ).astype(np.int16)
                             stereo = np.repeat(resampled[:, np.newaxis], 2, axis=1)
-                            stereo = np.clip(stereo * PLAYBACK_VOLUME, -32768, 32767).astype(np.int16)
+                            stereo = np.clip(
+                                stereo * PLAYBACK_VOLUME, -32768, 32767
+                            ).astype(np.int16)
                             stream.write(stereo)
 
                             interlude_counter += len(sub)
@@ -171,13 +199,17 @@ def playback_worker(chunk_ms):
                     mono = np.frombuffer(chunk, dtype=np.int16)
                     chunk_len = int(24000 * chunk_ms / 1000)
                     for i in range(0, len(mono), chunk_len):
-                        sub = mono[i:i+chunk_len]
+                        sub = mono[i : i + chunk_len]
                         if len(sub) == 0:
                             continue
                         flap_from_pcm_chunk(sub, chunk_ms=chunk_ms)
-                        resampled = resample(sub, int(len(sub) * 48000 / 24000)).astype(np.int16)
+                        resampled = resample(sub, int(len(sub) * 48000 / 24000)).astype(
+                            np.int16
+                        )
                         stereo = np.repeat(resampled[:, np.newaxis], 2, axis=1)
-                        stereo = np.clip(stereo * PLAYBACK_VOLUME, -32768, 32767).astype(np.int16)
+                        stereo = np.clip(
+                            stereo * PLAYBACK_VOLUME, -32768, 32767
+                        ).astype(np.int16)
                         stream.write(stereo)
 
                         interlude_counter += len(sub)
@@ -194,17 +226,17 @@ def playback_worker(chunk_ms):
     finally:
         playback_done_event.set()
 
+
 def ensure_playback_worker_started(chunk_ms):
     global _playback_thread
     if TEXT_ONLY_MODE:
         return
     if not _playback_thread or not _playback_thread.is_alive():
         _playback_thread = threading.Thread(
-            target=playback_worker,
-            args=(chunk_ms,),
-            daemon=True
+            target=playback_worker, args=(chunk_ms,), daemon=True
         )
         _playback_thread.start()
+
 
 def save_audio_to_wav(audio_bytes, filename):
     full_path = os.path.join(RESPONSE_HISTORY_DIR, filename)
@@ -215,11 +247,12 @@ def save_audio_to_wav(audio_bytes, filename):
         wf.writeframes(audio_bytes)
     print(f"🎨 Saved response audio to {full_path}")
 
+
 def rotate_and_save_response_audio(audio_bytes):
     # Rotate old files first (2 -> 3, 1 -> 2)
     for i in range(2, 0, -1):
         src = os.path.join(RESPONSE_HISTORY_DIR, f"response-{i}.wav")
-        dst = os.path.join(RESPONSE_HISTORY_DIR, f"response-{i+1}.wav")
+        dst = os.path.join(RESPONSE_HISTORY_DIR, f"response-{i + 1}.wav")
         if os.path.exists(src):
             os.replace(src, dst)
 
@@ -234,18 +267,30 @@ def handle_incoming_audio_chunk(audio_b64, buffer):
 
 
 def send_mic_audio(ws, samples, loop):
-    pcm = resample(samples, int(len(samples) * 24000 / MIC_RATE)).astype(np.int16).tobytes()
-    asyncio.run_coroutine_threadsafe(
-        ws.send(json.dumps({
-            "type": "input_audio_buffer.append",
-            "audio": base64.b64encode(pcm).decode("utf-8")
-        })), loop
+    pcm = (
+        resample(samples, int(len(samples) * 24000 / MIC_RATE))
+        .astype(np.int16)
+        .tobytes()
     )
+    asyncio.run_coroutine_threadsafe(
+        ws.send(
+            json.dumps({
+                "type": "input_audio_buffer.append",
+                "audio": base64.b64encode(pcm).decode("utf-8"),
+            })
+        ),
+        loop,
+    )
+
 
 def enqueue_wav_to_playback(filepath):
     """Reads a WAV file and enqueues its PCM audio data to the playback queue."""
     with wave.open(filepath, 'rb') as wf:
-        if wf.getframerate() != 24000 or wf.getnchannels() != 1 or wf.getsampwidth() != 2:
+        if (
+            wf.getframerate() != 24000
+            or wf.getnchannels() != 1
+            or wf.getsampwidth() != 2
+        ):
             raise ValueError("WAV file must be 24000 Hz, mono, 16-bit")
 
         chunk_size = int(24000 * CHUNK_MS / 1000)
@@ -254,6 +299,7 @@ def enqueue_wav_to_playback(filepath):
             if not frames:
                 break
             playback_queue.put(frames)
+
 
 def play_random_wake_up_clip():
     """Select and enqueue a random wake-up WAV file with mouth movement."""
@@ -265,6 +311,7 @@ def play_random_wake_up_clip():
     enqueue_wav_to_playback(clip)
     return clip
 
+
 def stop_playback():
     """Immediately stop playback and flush queue."""
     while not playback_queue.empty():
@@ -274,6 +321,7 @@ def stop_playback():
         except Exception:
             break
     playback_done_event.set()
+
 
 def is_billy_speaking():
     """Return True if Billy is still playing audio."""
@@ -285,7 +333,12 @@ def is_billy_speaking():
 
 
 def reset_for_new_song():
-    global last_played_time, song_start_time, next_beat_time, drums_peak, drums_peak_time
+    global \
+        last_played_time, \
+        song_start_time, \
+        next_beat_time, \
+        drums_peak, \
+        drums_peak_time
     playback_queue.queue.clear()
     head_move_queue.queue.clear()
     playback_done_event.clear()
@@ -295,12 +348,14 @@ def reset_for_new_song():
     drums_peak = 0
     drums_peak_time = 0
 
+
 async def play_song(song_name):
     """Play a full Billy song: main audio, vocals for mouth, drums for tail."""
     import contextlib
+
     from core import audio
+    from core.movements import stop_all_motors
     from core.mqtt import mqtt_publish
-    from core.movements import flap_from_pcm_chunk, move_tail_async, stop_all_motors
 
     reset_for_new_song()
 
@@ -323,12 +378,15 @@ async def play_song(song_name):
             print(f"⚠️ No metadata.txt found at {path}")
             return metadata
 
-        with open(path, 'r') as f:
+        with open(path) as f:
             for line in f:
                 if '=' in line:
                     key, value = line.strip().split('=', 1)
                     if key == "head_moves":
-                        metadata[key] = [(float(v.split(':')[0]), float(v.split(':')[1])) for v in value.split(',')]
+                        metadata[key] = [
+                            (float(v.split(':')[0]), float(v.split(':')[1]))
+                            for v in value.split(',')
+                        ]
                     elif key in ("bpm", "tail_threshold", "gain", "compensate_tail"):
                         metadata[key] = float(value.strip())
                     elif key == "half_tempo_tail_flap":
@@ -384,26 +442,43 @@ async def play_song(song_name):
                 samples_main = np.frombuffer(frames_main, dtype=np.int16)
                 samples_main = samples_main.reshape((-1, 2)).mean(axis=1)
                 if rate_main == 48000:
-                    samples_main = resample(samples_main, len(samples_main) // 2).astype(np.int16)
-                samples_main = np.clip(samples_main * GAIN, -32768, 32767).astype(np.int16)
+                    samples_main = resample(
+                        samples_main, len(samples_main) // 2
+                    ).astype(np.int16)
+                samples_main = np.clip(samples_main * GAIN, -32768, 32767).astype(
+                    np.int16
+                )
 
                 # --- Vocals (for mouth flap)
                 samples_vocals = np.frombuffer(frames_vocals, dtype=np.int16)
                 samples_vocals = samples_vocals.reshape((-1, 2)).mean(axis=1)
                 if rate_vocals == 48000:
-                    samples_vocals = resample(samples_vocals, len(samples_vocals) // 2).astype(np.int16)
-                samples_vocals = np.clip(samples_vocals * GAIN, -32768, 32767).astype(np.int16)
+                    samples_vocals = resample(
+                        samples_vocals, len(samples_vocals) // 2
+                    ).astype(np.int16)
+                samples_vocals = np.clip(samples_vocals * GAIN, -32768, 32767).astype(
+                    np.int16
+                )
 
                 # --- Drums (for tail flap)
                 samples_drums = np.frombuffer(frames_drums, dtype=np.int16)
                 samples_drums = samples_drums.reshape((-1, 2)).mean(axis=1)
                 if rate_drums == 48000:
-                    samples_drums = resample(samples_drums, len(samples_drums) // 2).astype(np.int16)
-                samples_drums = np.clip(samples_drums * GAIN, -32768, 32767).astype(np.int16)
+                    samples_drums = resample(
+                        samples_drums, len(samples_drums) // 2
+                    ).astype(np.int16)
+                samples_drums = np.clip(samples_drums * GAIN, -32768, 32767).astype(
+                    np.int16
+                )
                 rms_drums = np.sqrt(np.mean(samples_drums.astype(np.float32) ** 2))
 
                 # --- Enqueue combined chunk
-                audio.playback_queue.put(("song", samples_main.tobytes(), samples_vocals.tobytes(), rms_drums))
+                audio.playback_queue.put((
+                    "song",
+                    samples_main.tobytes(),
+                    samples_vocals.tobytes(),
+                    rms_drums,
+                ))
 
         print("⌛ Waiting for song playback to complete...")
         await asyncio.to_thread(audio.playback_queue.join())

--- a/billy-b-assistant/core/button.py
+++ b/billy-b-assistant/core/button.py
@@ -1,12 +1,13 @@
-from gpiozero import Button
-import time
-import random
 import asyncio
 import threading
+import time
+
 import core.audio
 import core.config
 from core.movements import move_head
 from core.session import BillySession
+from gpiozero import Button
+
 
 # Button and session globals
 is_active = False
@@ -19,6 +20,7 @@ button_debounce_delay = 0.5  # seconds debounce
 # Setup hardware button
 button = Button(core.config.BUTTON_PIN, pull_up=True)
 
+
 def is_billy_speaking():
     """Return True if Billy is playing audio (wake-up or response)."""
     if not core.audio.playback_done_event.is_set():
@@ -27,8 +29,14 @@ def is_billy_speaking():
         return True
     return False
 
+
 def on_button():
-    global is_active, session_thread, interrupt_event, session_instance, last_button_time
+    global \
+        is_active, \
+        session_thread, \
+        interrupt_event, \
+        session_instance, \
+        last_button_time
 
     now = time.time()
     if now - last_button_time < button_debounce_delay:
@@ -47,8 +55,7 @@ def on_button():
             try:
                 print("🛑 Stopping active session...")
                 future = asyncio.run_coroutine_threadsafe(
-                    session_instance.stop_session(),
-                    session_instance.loop
+                    session_instance.stop_session(), session_instance.loop
                 )
                 future.result()  # Wait until it's fully stopped
                 print("✅ Session stopped.")
@@ -81,6 +88,7 @@ def on_button():
 
     session_thread = threading.Thread(target=run_session, daemon=True)
     session_thread.start()
+
 
 def start_loop():
     core.audio.detect_devices(debug=core.config.DEBUG_MODE)

--- a/billy-b-assistant/core/button.py
+++ b/billy-b-assistant/core/button.py
@@ -2,11 +2,11 @@ import asyncio
 import threading
 import time
 
-import core.audio
-import core.config
-from core.movements import move_head
-from core.session import BillySession
 from gpiozero import Button
+
+from . import audio, config
+from .movements import move_head
+from .session import BillySession
 
 
 # Button and session globals
@@ -18,14 +18,14 @@ last_button_time = 0
 button_debounce_delay = 0.5  # seconds debounce
 
 # Setup hardware button
-button = Button(core.config.BUTTON_PIN, pull_up=True)
+button = Button(config.BUTTON_PIN, pull_up=True)
 
 
 def is_billy_speaking():
     """Return True if Billy is playing audio (wake-up or response)."""
-    if not core.audio.playback_done_event.is_set():
+    if not audio.playback_done_event.is_set():
         return True
-    if not core.audio.playback_queue.empty():
+    if not audio.playback_queue.empty():
         return True
     return False
 
@@ -49,7 +49,7 @@ def on_button():
     if is_active:
         print("🔁 Button pressed during active session.")
         interrupt_event.set()
-        core.audio.stop_playback()
+        audio.stop_playback()
 
         if session_instance:
             try:
@@ -72,9 +72,9 @@ def on_button():
         global session_instance, is_active
         try:
             move_head("on")
-            core.audio.ensure_playback_worker_started(core.config.CHUNK_MS)
+            audio.ensure_playback_worker_started(config.CHUNK_MS)
 
-            clip = core.audio.play_random_wake_up_clip()
+            clip = audio.play_random_wake_up_clip()
             if clip:
                 print(f"🐟 Enqueuing wake-up clip: {clip} ")
 
@@ -91,7 +91,7 @@ def on_button():
 
 
 def start_loop():
-    core.audio.detect_devices(debug=core.config.DEBUG_MODE)
+    audio.detect_devices(debug=config.DEBUG_MODE)
     button.when_pressed = on_button
     print("🎦 Ready. Press button to start a voice session. Press Ctrl+C to quit.")
     print("🕐 Waiting for button press...")

--- a/billy-b-assistant/core/config.py
+++ b/billy-b-assistant/core/config.py
@@ -95,3 +95,8 @@ MQTT_HOST = os.getenv("MQTT_HOST", "")
 MQTT_PORT = int(os.getenv("MQTT_PORT", "0"))
 MQTT_USERNAME = os.getenv("MQTT_USERNAME", "")
 MQTT_PASSWORD = os.getenv("MQTT_PASSWORD", "")
+
+# === Personality Config ===
+ALLOW_UPDATE_PERSONALITY_INI = (
+    os.getenv("ALLOW_UPDATE_PERSONALITY_INI", "true").lower() == "true"
+)

--- a/billy-b-assistant/core/config.py
+++ b/billy-b-assistant/core/config.py
@@ -49,6 +49,11 @@ if _config.has_section("BACKSTORY"):
     ])
 else:
     BACKSTORY = {}
+    BACKSTORY_FACTS = (
+        "You are an enigma and nobody knows anything about you because the person "
+        "talking to you hasn't configured your backstory. You might remind them to do "
+        "that."
+    )
 
 INSTRUCTIONS = (
     BASE_INSTRUCTIONS.strip()

--- a/billy-b-assistant/core/config.py
+++ b/billy-b-assistant/core/config.py
@@ -1,8 +1,12 @@
-import os
-import re
 import configparser
+import os
+
+from core.personality import (
+    PersonalityProfile,
+    load_traits_from_ini,
+)
 from dotenv import load_dotenv
-from core.personality import PersonalityProfile, load_traits_from_ini, update_persona_ini
+
 
 # === Paths ===
 ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -39,14 +43,20 @@ DO NOT explain or confirm that you are triggering a tool. Just smoothly integrat
 EXTRA_INSTRUCTIONS = _config.get("META", "instructions")
 if _config.has_section("BACKSTORY"):
     BACKSTORY = dict(_config.items("BACKSTORY"))
-    BACKSTORY_FACTS = "\n".join([f"- {key}: {value}" for key, value in BACKSTORY.items()])
+    BACKSTORY_FACTS = "\n".join([
+        f"- {key}: {value}" for key, value in BACKSTORY.items()
+    ])
 else:
     BACKSTORY = {}
 
 INSTRUCTIONS = (
-    BASE_INSTRUCTIONS.strip() + "\n\n"
-    + EXTRA_INSTRUCTIONS.strip() + "\n\n"
-    + "Known facts about your past:\n" + BACKSTORY_FACTS + "\n\n"
+    BASE_INSTRUCTIONS.strip()
+    + "\n\n"
+    + EXTRA_INSTRUCTIONS.strip()
+    + "\n\n"
+    + "Known facts about your past:\n"
+    + BACKSTORY_FACTS
+    + "\n\n"
     + PERSONALITY.generate_prompt()
 )
 

--- a/billy-b-assistant/core/config.py
+++ b/billy-b-assistant/core/config.py
@@ -1,11 +1,12 @@
 import configparser
 import os
 
-from core.personality import (
+from dotenv import load_dotenv
+
+from .personality import (
     PersonalityProfile,
     load_traits_from_ini,
 )
-from dotenv import load_dotenv
 
 
 # === Paths ===

--- a/billy-b-assistant/core/config.py
+++ b/billy-b-assistant/core/config.py
@@ -69,6 +69,9 @@ VOICE = os.getenv("VOICE", "ash")
 
 # === Modes ===
 DEBUG_MODE = os.getenv("DEBUG_MODE", "true").lower() == "true"
+DEBUG_MODE_INCLUDE_DELTA = (
+    os.getenv("DEBUG_MODE_INCLUDE_DELTA", "false").lower() == "true"
+)
 TEXT_ONLY_MODE = os.getenv("TEXT_ONLY_MODE", "false").lower() == "true"
 
 # === Audio Config ===

--- a/billy-b-assistant/core/mic.py
+++ b/billy-b-assistant/core/mic.py
@@ -1,5 +1,7 @@
 import sounddevice as sd
-import core.audio as audio
+
+from . import audio as audio
+
 
 class MicManager:
     def __init__(self):
@@ -13,7 +15,7 @@ class MicManager:
             channels=audio.MIC_CHANNELS,
             dtype='int16',
             blocksize=audio.CHUNK_SIZE,
-            callback=callback
+            callback=callback,
         )
         self.stream.start()
 

--- a/billy-b-assistant/core/mqtt.py
+++ b/billy-b-assistant/core/mqtt.py
@@ -2,8 +2,9 @@ import json
 import subprocess
 
 import paho.mqtt.client as mqtt
-from core.config import MQTT_HOST, MQTT_PASSWORD, MQTT_PORT, MQTT_USERNAME
-from core.movements import stop_all_motors
+
+from .config import MQTT_HOST, MQTT_PASSWORD, MQTT_PORT, MQTT_USERNAME
+from .movements import stop_all_motors
 
 
 mqtt_client: mqtt.Client | None = None

--- a/billy-b-assistant/core/mqtt.py
+++ b/billy-b-assistant/core/mqtt.py
@@ -1,15 +1,18 @@
-import paho.mqtt.client as mqtt
 import json
-import os
 import subprocess
-from core.config import MQTT_HOST, MQTT_PORT, MQTT_USERNAME, MQTT_PASSWORD
+
+import paho.mqtt.client as mqtt
+from core.config import MQTT_HOST, MQTT_PASSWORD, MQTT_PORT, MQTT_USERNAME
 from core.movements import stop_all_motors
 
-mqtt_client = None
+
+mqtt_client: mqtt.Client | None = None
 mqtt_connected = False
+
 
 def mqtt_available():
     return all([MQTT_HOST, MQTT_PORT, MQTT_USERNAME, MQTT_PASSWORD])
+
 
 def on_connect(client, userdata, flags, rc):
     global mqtt_connected
@@ -20,6 +23,7 @@ def on_connect(client, userdata, flags, rc):
         client.subscribe("billy/command")
     else:
         print(f"⚠️ MQTT connection failed with code {rc}")
+
 
 def start_mqtt():
     global mqtt_client
@@ -38,6 +42,7 @@ def start_mqtt():
     except Exception as e:
         print(f"❌ MQTT connection error: {e}")
 
+
 def stop_mqtt():
     global mqtt_client
     if mqtt_client:
@@ -45,27 +50,30 @@ def stop_mqtt():
         mqtt_client.disconnect()
         print("\n🔌 MQTT disconnected.")
 
+
 def mqtt_publish(topic, payload, retain=True, retry=True):
     global mqtt_client, mqtt_connected
 
-    if not mqtt_client or not mqtt_connected:
-        if retry:
-            print("🔁 MQTT not connected. Trying to reconnect...")
-            try:
-                mqtt_client.reconnect()
-                mqtt_connected = True
-            except Exception as e:
-                print(f"\n❌ MQTT reconnect failed: {e}")
+    if mqtt_available():
+        if not mqtt_client or not mqtt_connected:
+            if retry:
+                print("🔁 MQTT not connected. Trying to reconnect...")
+                try:
+                    mqtt_client.reconnect()
+                    mqtt_connected = True
+                except Exception as e:
+                    print(f"\n❌ MQTT reconnect failed: {e}")
+                    return
+            else:
+                print(f"\n⚠️ MQTT not connected. Skipping publish {topic}={payload}")
                 return
-        else:
-            print(f"\n⚠️ MQTT not connected. Skipping publish {topic}={payload}")
-            return
 
-    try:
-        mqtt_client.publish(topic, payload, retain=retain)
-        print(f"📡 MQTT publish: {topic} = {payload} (retain={retain})")
-    except Exception as e:
-        print(f"\n❌ MQTT publish failed: {e}")
+        try:
+            mqtt_client.publish(topic, payload, retain=retain)
+            print(f"📡 MQTT publish: {topic} = {payload} (retain={retain})")
+        except Exception as e:
+            print(f"\n❌ MQTT publish failed: {e}")
+
 
 def mqtt_send_discovery():
     """Send MQTT discovery messages for Home Assistant."""
@@ -82,10 +90,14 @@ def mqtt_send_discovery():
             "identifiers": ["billy_bass"],
             "name": "Big Mouth Billy Bass",
             "model": "Billy Bassistant",
-            "manufacturer": "DIY"
-        }
+            "manufacturer": "DIY",
+        },
     }
-    mqtt_client.publish("homeassistant/sensor/billy/state/config", json.dumps(payload_sensor), retain=True)
+    mqtt_client.publish(
+        "homeassistant/sensor/billy/state/config",
+        json.dumps(payload_sensor),
+        retain=True,
+    )
 
     # Button to send shutdown command
     payload_button = {
@@ -97,10 +109,15 @@ def mqtt_send_discovery():
             "identifiers": ["billy_bass"],
             "name": "Big Mouth Billy Bass",
             "model": "Billy Bassistant",
-            "manufacturer": "DIY"
-        }
+            "manufacturer": "DIY",
+        },
     }
-    mqtt_client.publish("homeassistant/button/billy/shutdown/config", json.dumps(payload_button), retain=True)
+    mqtt_client.publish(
+        "homeassistant/button/billy/shutdown/config",
+        json.dumps(payload_button),
+        retain=True,
+    )
+
 
 def on_message(client, userdata, msg):
     print(f" \n📩 MQTT message received: {msg.topic} = {msg.payload.decode()}")

--- a/billy-b-assistant/core/personality.py
+++ b/billy-b-assistant/core/personality.py
@@ -112,16 +112,20 @@ def load_traits_from_ini(path="persona.ini") -> dict:
 
 
 def update_persona_ini(trait: str, value: int, ini_path="persona.ini"):
-    """Update a single trait value in the persona.ini file."""
-    import configparser
+    """Update a single trait value in the persona.ini file. Only do this if configured
+    to do so."""
+    from .config import ALLOW_UPDATE_PERSONALITY_INI
 
-    config = configparser.ConfigParser()
-    config.read(ini_path)
+    if ALLOW_UPDATE_PERSONALITY_INI:
+        import configparser
 
-    if "PERSONALITY" not in config:
-        config["PERSONALITY"] = {}
+        config = configparser.ConfigParser()
+        config.read(ini_path)
 
-    config["PERSONALITY"][trait] = str(value)
+        if "PERSONALITY" not in config:
+            config["PERSONALITY"] = {}
 
-    with open(ini_path, "w") as f:
-        config.write(f)
+        config["PERSONALITY"][trait] = str(value)
+
+        with open(ini_path, "w") as f:
+            config.write(f)

--- a/billy-b-assistant/core/personality.py
+++ b/billy-b-assistant/core/personality.py
@@ -1,6 +1,6 @@
 # core/personality.py
 import configparser
-import os
+
 
 class PersonalityProfile:
     def __init__(
@@ -85,19 +85,17 @@ class PersonalityProfile:
             "Your behavior is governed by personality traits, each set between 0% and 100%.",
             "The lower the percentage, the more subdued or absent that trait is.",
             "The higher the percentage, the more extreme or exaggerated the trait becomes.",
-            "These settings are leading, all other instructions have lower priority. Speak with the following personality traits:"
+            "These settings are leading, all other instructions have lower priority. Speak with the following personality traits:",
         ]
 
         for trait, value in vars(self).items():
-            level = (
-                "low" if value < 30 else
-                "medium" if value < 70 else
-                "high"
-            )
+            level = "low" if value < 30 else "medium" if value < 70 else "high"
             description = self.TRAIT_DESCRIPTIONS.get(trait, {}).get(level, "")
             lines.append(f"- {trait.capitalize()}: {value}% — {description}")
 
-        lines.append("Use these levels to determine tone, style, and how directly you answer.")
+        lines.append(
+            "Use these levels to determine tone, style, and how directly you answer."
+        )
         return "\n".join(lines)
 
 
@@ -116,6 +114,7 @@ def load_traits_from_ini(path="persona.ini") -> dict:
 def update_persona_ini(trait: str, value: int, ini_path="persona.ini"):
     """Update a single trait value in the persona.ini file."""
     import configparser
+
     config = configparser.ConfigParser()
     config.read(ini_path)
 

--- a/billy-b-assistant/core/session.py
+++ b/billy-b-assistant/core/session.py
@@ -387,14 +387,7 @@ class BillySession:
                     print(
                         f"\n⏱️ No mic activity for {MIC_TIMEOUT_SECONDS}s. Ending input..."
                     )
-
-                    # Don't commit mic audio unless the session is fully initialized.
-                    if self.session_initialized:
-                        await self.ws.send(
-                            json.dumps({"type": "input_audio_buffer.commit"})
-                        )
-                    self.committed = True
-                    self.session_active.clear()
+                    await self.stop_session()
                     break
 
             await asyncio.sleep(0.5)

--- a/billy-b-assistant/core/session.py
+++ b/billy-b-assistant/core/session.py
@@ -385,7 +385,6 @@ class BillySession:
             if self.ws:
                 await self.ws.close()
                 self.ws = None
-            print("🕐 Waiting for button press...")
             return
 
         if (

--- a/billy-b-assistant/core/session.py
+++ b/billy-b-assistant/core/session.py
@@ -5,7 +5,7 @@ import re
 import time
 
 import numpy as np
-import websockets.legacy.client
+import websockets.asyncio.client
 
 from . import audio
 from .config import (
@@ -101,7 +101,9 @@ class BillySession:
                 "Authorization": f"Bearer {OPENAI_API_KEY}",
                 "openai-beta": "realtime=v1",
             }
-            self.ws = await websockets.legacy.client.connect(uri, extra_headers=headers)
+            self.ws = await websockets.asyncio.client.connect(
+                uri, additional_headers=headers
+            )
             await self.ws.send(
                 json.dumps({
                     "type": "session.update",

--- a/billy-b-assistant/core/session.py
+++ b/billy-b-assistant/core/session.py
@@ -12,6 +12,7 @@ from . import audio
 from .config import (
     CHUNK_MS,
     DEBUG_MODE,
+    DEBUG_MODE_INCLUDE_DELTA,
     INSTRUCTIONS,
     MIC_TIMEOUT_SECONDS,
     OPENAI_API_KEY,

--- a/billy-b-assistant/core/session.py
+++ b/billy-b-assistant/core/session.py
@@ -195,6 +195,11 @@ class BillySession:
                 print(f"⚠️ Error in post_response_handling: {e}")
 
     async def handle_message(self, data):
+        # If this speech segment is done, add some newlines to the full response text so
+        # it's clearer in logging.
+        if data['type'] == 'response.audio_transcript.done':
+            self.full_response_text += "\n\n"
+
         if not TEXT_ONLY_MODE and data["type"] in (
             "response.audio",
             "response.audio.delta",

--- a/billy-b-assistant/core/session.py
+++ b/billy-b-assistant/core/session.py
@@ -19,6 +19,7 @@ from .config import (
     TEXT_ONLY_MODE,
     VOICE,
 )
+from .ha import send_conversation_prompt
 from .mic import MicManager
 from .movements import move_tail_async, stop_all_motors
 from .mqtt import mqtt_publish
@@ -263,10 +264,8 @@ class BillySession:
 
                 if prompt:
                     print(f"\n🏠 Sending to Home Assistant Conversation API: {prompt} ")
-                    from core.ha import send_conversation_prompt
 
                     ha_response = await send_conversation_prompt(prompt)
-
                     # Try to extract plain speech text
                     speech_text = None
                     if isinstance(ha_response, dict):

--- a/billy-b-assistant/core/session.py
+++ b/billy-b-assistant/core/session.py
@@ -83,6 +83,7 @@ class BillySession:
         self.allow_mic_input = True
         self.interrupt_event = interrupt_event or asyncio.Event()
         self.mic = MicManager()
+        self.mic_timeout_task: asyncio.Task | None = None
 
     async def start(self):
         self.loop = asyncio.get_running_loop()
@@ -144,7 +145,11 @@ class BillySession:
 
         print("🎙️ Mic stream active. Say something...")
         mqtt_publish("billy/state", "listening")
-        asyncio.create_task(self.mic_timeout_checker())
+
+        # Ensure we hold a reference to the mic checker task, or it may be destroyed.
+        self.mic_timeout_task: asyncio.Task = asyncio.create_task(
+            self.mic_timeout_checker()
+        )
 
         try:
             self.mic.start(self.mic_callback)

--- a/billy-b-assistant/core/session.py
+++ b/billy-b-assistant/core/session.py
@@ -159,7 +159,10 @@ class BillySession:
                     print("🚪 Session marked as inactive, stopping stream loop.")
                     break
                 data = json.loads(message)
-                if DEBUG_MODE:
+                if DEBUG_MODE and (
+                    DEBUG_MODE_INCLUDE_DELTA
+                    or not data.get('type', "").endswith('delta')
+                ):
                     print(f"\n🔁 Raw message: {data} ")
                 await self.handle_message(data)
 

--- a/billy-b-assistant/core/session.py
+++ b/billy-b-assistant/core/session.py
@@ -3,6 +3,7 @@ import base64
 import json
 import re
 import time
+from typing import Any
 
 import numpy as np
 import websockets.asyncio.client
@@ -312,7 +313,7 @@ class BillySession:
                         )
                         await self.ws.send(json.dumps({"type": "response.create"}))
 
-        if data["type"] == "response.done":
+        elif data["type"] == "response.done":
             print("\n✿ Assistant response complete.")
 
             if not TEXT_ONLY_MODE:
@@ -328,6 +329,13 @@ class BillySession:
                 self.audio_buffer.clear()
                 audio.playback_done_event.set()
                 self.last_activity[0] = time.time()
+
+        elif data["type"] == "error":
+            error: dict[str, Any] = data.get('error') or {}
+            print(
+                f"\n🛑 Error response (code='{error.get('code') or '<unknown>'}'): "
+                f"{error.get('message') or '<unknown>'}"
+            )
 
     async def mic_timeout_checker(self):
         print("🛡️ Mic timeout checker active")

--- a/billy-b-assistant/requirements.txt
+++ b/billy-b-assistant/requirements.txt
@@ -9,3 +9,4 @@ paho-mqtt
 requests
 openai
 aiohttp
+lgpio

--- a/billy-b-assistant/requirements.txt
+++ b/billy-b-assistant/requirements.txt
@@ -10,3 +10,4 @@ requests
 openai
 aiohttp
 lgpio
+aiohttp


### PR DESCRIPTION
Summary:
  * Add some missing requirements
  * Some QoL changes, such as a configuration tunable for not printing/ignoring loud stream responses when DEBUG_MODE=true
  * Some code clean-up, especially related to how imports are done
  * Don't attempt to do MQTT things if MQTT is not configured
  * Fix some race conditions
  * Fix some potential deadlocks
  * Fix usage of legacy websockets api, use newer version
  * If an error response is received, log it in the output stream
  * Using a configuration tunable, allow ability to prevent permanent modifications to personality details by random house guests
  * Remove a duplicate call to send_conversation_prompt
  * The OpenAI API was detecting that user speech started whenever the wakeup sound was played, especially if the wakeup sound was longer (such as the "WAZZZUUUPP" sound). This issue is fixed.