### PR TITLE
Contributions to v1.2.0 Dev

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,70 @@
+# MACOS-SPECIFIC FILES
+## General
+.DS_Store
+.AppleDouble
+.LSOverride
+Icon[]
+
+## Thumbnails
+._*
+
+## Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+## Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+# WINDOWS-SPECIFIC FILES
+## Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+## Dump file
+*.stackdump
+
+## Folder config file
+[Dd]esktop.ini
+
+## Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+## Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+## Windows shortcuts
+*.lnk
+
+# IDE-SPECIFIC FILES
+.idea/				# JetBrains IDEs
+.vscode/			# VS Code settings
+*.suo				# Visual Studio solution user options
+*.user				# Visual Studio user options
+*.vcproj.filters	# Visual C++ project filters
+*.sln.docstates		# Visual Studio solution document states
+
+# PYTHON-SPECIFIC FILES
+core/__pycache__/
+
+# PROJECT-SPECIFIC FILES
 .idea
 .env
 persona.ini
 versions.ini
-*.DS_Store
+venv
 webconfig/node_modules
-core/__pycache__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ All notable changes to this project will be documented in this file.
 - Adjustable silence threshold and mic timeout for voice session logic.
 
 **MQTT Integration (Optional)**
-- Basic MQTT connectivity for status reporting, safe shutdown raspberry pi command and future integration with Home Assistant.
+- Basic MQTT connectivity for status reporting, safe shutdown Raspberry Pi command and future integration with Home Assistant.
 
 **Song Mode**
 - Folder-based song playback system supporting:

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,5 @@
 # Billy B-Assistant — Personal and Educational Use License #  
+
 Copyright (c) 2025 Thom Koopman
 
 This project is made available free of charge for **personal, non-commercial, and educational use**.
@@ -19,7 +20,7 @@ You are encouraged to explore, modify, and share the project for your own learni
 ## Commercial Use
 
 If you are interested in using this project commercially or as part of a product or service, please contact:
-**license@thomkoopman.nl**
+**<license@thomkoopman.nl>**
 
 ## Attribution
 

--- a/README.md
+++ b/README.md
@@ -1,55 +1,82 @@
 # Billy B-Assistant
 
-The **Billy Bass Assistant** is a Raspberry Pi–powered voice assistant embedded inside a Big Mouth Billy Bass Animatronic.
-It streams conversation using the OpenAI Realtime API, turns its head, flaps it's tail and moves his mouth based on what he is saying.
+The **Billy Bass Assistant** is a Raspberry Pi–powered voice assistant embedded inside a Big Mouth Billy Bass Animatronic. It streams conversation using the OpenAI Realtime API, turns its head, flaps it's tail and moves his mouth based on what he is saying.
 
 > **This project is still in BETA.** Things might crash, get stuck or make Billy scream uncontrollably (ok that last part maybe not literally but you get the point). Proceed with fishy caution.
-
 
 ![Billy Bathroom](./docs/images/billy_bathroom.jpeg)
 ---
 
-##  Features
+## Features
 
 - Realtime conversations using OpenAI GPT-4o-mini
 - 3D-printable backplate for housing USB microphone and speaker
 - Lightweight web UI for editing configuration, logs, and systemd service control
-- Support for the Modern Billy hardware version with 2 motors as well as the Classic Billy hardware version (3 motors) 
+- Support for the Modern Billy hardware version with 2 motors as well as the Classic Billy hardware version (3 motors)
 - Physical button to start/interact/intervene
 - Personality system with configurable traits (e.g., snark, charm)
 - MQTT support:
- - sensor with status updates of Billy (idle, speaking, listening)
- - `billy/say` topic for triggering spoken messages remotely (feature in beta)
- - Raspberry Pi Safe Shutdown command
+  - sensor with status updates of Billy (idle, speaking, listening)
+  - `billy/say` topic for triggering spoken messages remotely (feature in beta)
+  - Raspberry Pi Safe Shutdown command
 - Home Assistant command passthrough using the Conversation API
 - Custom Song Singing and animation mode
 
 ---
 
+## Hardware build instructions
 
-# Instructions
-
-## 1. Flash Raspberry Pi OS Lite
-
-1. Download **Raspberry Pi OS Lite (64-bit)** from the official [Raspberry Pi Downloads](https://www.raspberrypi.com/software/operating-systems/).
-2. Flash it onto a microSD card using the [Raspberry Pi Imager](https://www.raspberrypi.com/software/).
-3. In the Imager, **before flashing**, click the ⚙️ gear icon in the bottom-right corner:
-    - Set **hostname** (e.g., `raspberrypi.local`)
-    - Enable **SSH** and provide a password
-    - Set **username** to `billy` (or your own preference)
-    - Configure **Wi-Fi** (SSID, password, country)
-4. Click “Save,” then flash the card.
-5. Insert the SD card into the Raspberry Pi and power it on.
+See [BUILDME.md](./docs/BUILDME.md) for detailed build/wiring instructions.
 
 ---
 
-## 2. Initial Setup
+# Instructions
+
+## A. Flash Raspberry Pi OS Lite
+
+Flash the operating system onto a microSD card using the [Raspberry Pi Imager](https://www.raspberrypi.com/software/).
+
+1. In the Imager,
+    - **Choose device** `Raspberry Pi 5` (to match your hardware)
+    - **Choose OS** `Raspberry Pi OS (other)` and then `Raspberry Pi OS Lite (64-bit)`
+    - **Choose storage** and select your microSD card
+
+2. You will be asked **Would you like to apply OS customisation settings?**, select `Edit Settings`
+    - On the `General` tab,
+      - **Set hostname** (e.g., `raspberrypi.local`)
+      - **Set username and password** (`pi` and `pi` is the default)
+      - **Configure wireless LAN** (SSID, Password, Wireless LAN country)
+      - **Set locale settings** (Time zone, Keyboard layout)
+    - On the `Services` tab,
+      - **Enable SSH**
+      - Use password authentication or provide an authorized key
+    - On the `Options` tab, set to your preference
+      - Click `Save`
+
+3. Back on the **Would you like to apply OS customisation settings?**, select `Yes` to apply settings
+
+4. You will be asked **All existing data on 'SDXC Card' will be erased. Are you sure you want to continue?**, select `Yes`
+
+5. Wait for flash to complete and verify
+
+6. Insert the SD card into the Raspberry Pi and power it on
+
+---
+
+## B. Initial Setup
 
 Connect via SSH from your computer:
 
 ```bash
-ssh billy@raspberrypi.local
-# (replace 'billy' with your username if different)
+ssh pi@raspberrypi.local
+```
+
+Replace `pi` with your username (e.g. `billy`) if you opted to change it in the previous step.
+
+Expand the filesystem to fill available storage:
+
+```bash
+raspi-config --expand-rootfs
 ```
 
 Update the system:
@@ -61,11 +88,9 @@ sudo reboot
 
 ---
 
-## 3. GPIO Voltage Configuration (Motor Safety)
+## C. GPIO Voltage Configuration (Motor Safety)
 
-When the Raspberry Pi powers up, all GPIO pins are in an **undefined state** until the Billy B-Assistant software takes control.
-This can cause the **motor driver board to activate or stall** the motors momentarily.
-To prevent stalling and overheating the motors in case the software doesn't start, we set all the gpio pins to Low at boot:
+When the Raspberry Pi powers up, all GPIO pins are in an **undefined state** until the Billy B-Assistant software takes control. This can cause the **motor driver board to activate or stall** the motors momentarily. To prevent stalling and overheating the motors in case the software doesn't start, we set all the gpio pins to Low at boot:
 
 ### Set GPIO pins low on boot using `/boot/config.txt`
 
@@ -81,14 +106,91 @@ gpio=5=op,dl
 gpio=6=op,dl
 gpio=12=op,dl
 gpio=13=op,dl
+gpio=19=op,dl
+gpio=26=op,dl
 ```
 
 `op` = output  
-`dl` = drive low (0V)
+`dl` = drive low (0V)  
 
 This ensures the H-bridge input pins are inactive and motors remain off until the software initializes them properly.
 
-###  Reboot to apply
+---
+
+## D. Set Sound Configuration
+
+List all output soundcards and digital audio devices:
+
+```bash
+aplay -l
+```
+
+List all input soundcards and digital audio devices:
+
+```bash
+arecord -l
+```
+
+Edit the ALSA configuration. Replace `<speaker card>` with the device number of the speakers determined earlier:
+
+```bash
+sudo nano /usr/share/alsa/alsa.conf
+```
+
+```ini
+defaults.ctl.card <speaker card>
+defaults.pcm.card <speaker card>
+```
+
+Also create a `asound.conf` file (this file does not exist on a base system image). Replace `<mic card>,<mic sub>` and `<speaker card>,<speaker sub>` with the device numbers determined earlier:
+
+```bash
+sudo nano /etc/asound.conf
+```
+
+```ini
+pcm.!default {
+    type asym
+    capture.pcm "mic"
+    playback.pcm "speaker"
+}
+
+pcm.mic {
+    type plug
+    slave {
+        pcm "plughw:<mic card>,<mic sub>"
+    }
+}
+
+pcm.speaker {
+    type plug
+    slave {
+        pcm "plughw:<speaker card>,<speaker sub>"
+    }
+}
+```
+
+Adjust the playback and record levels:
+
+```bash
+alsamixer
+```
+
+Test output sound configuration:
+
+```bash
+aplay -D default /usr/share/sounds/alsa/Front_Center.wav
+```
+
+Test microphone input configuration:
+
+```bash
+arecord -vvv -f dat /dev/null
+```
+
+---
+
+## E. Reboot to Apply Changes
 
 Then reboot the Pi:
 
@@ -98,19 +200,18 @@ sudo reboot
 
 ---
 
-## 4. Clone the Project
+## F. Clone the Project
 
 On the Raspberry Pi:
 
 ```bash
 cd ~
-git clone https://github.com/yourusername/billy-b-assistant.git
-cd billy-b-assistant
+git clone https://github.com/Thokoop/billy-b-assistant.git
 ```
 
 ---
 
-## 5. Python Setup
+## G. Python Setup
 
 Make sure Python 3 is installed:
 
@@ -125,22 +226,138 @@ sudo apt update
 sudo apt install -y python3-pip libportaudio2 ffmpeg
 ```
 
-Install required Python dependencies globally:
+Create Python virtual environment:
 
 ```bash
-pip3 install -r requirements.txt
+cd billy-b-assistant
+python3 -m venv venv
+```
+
+Activate the Python virtual environment:
+
+```bash
+source .venv/bin/activate
+```
+
+To confirm the virtual environment is activated, check the location of your Python interpreter:
+
+```bash
+which python
+```
+
+Install required Python dependencies into the virtual environment:
+
+```bash
+pip3 install -r ./requirements.txt
 ```
 
 ---
 
-## 6. Hardware build instructions
-See [BUILDME.md for detailed build/wiring instructions.](./docs/BUILDME.md)
+## H. Systemd Services
+
+### Run Main As a Service
+
+To run Billy as a background service at boot, copy the service file from the repository to the `/etc/systemd/system` directory:
+
+```bash
+cp setup/system/billy.service /etc/systemd/system/billy.service
+```
+
+Adjust the username/paths if needed:
+
+```bash
+nano /etc/systemd/system/billy.service
+```
+
+```ini
+[Unit]
+Description=Billy Bass Assistant
+After=network.target sound.target
+
+[Service]
+Environment=PYTHONUNBUFFERED=1
+WorkingDirectory=/home/pi/billy-b-assistant
+ExecStart=/home/pi/billy-b-assistant/venv/bin/python /home/pi/billy-b-assistant/main.py
+Restart=always
+User=pi
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Enable the service and start:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable billy.service
+sudo systemctl start billy.service
+```
+
+To view status and logs:
+
+```bash
+sudo systemctl status billy.service
+journalctl -u billy-b-assistant.service -f
+```
+
+### Run The Web UI As A Service
+
+If you want the web interface to always be available, copy the service file from the repository to the `/etc/systemd/system` directory:
+
+```bash
+cp setup/system/billy-webconfig.service /etc/systemd/system/billy-webconfig.service
+```
+
+Adjust the username/paths if needed:
+
+```bash
+nano /etc/systemd/system/billy-webconfig.service
+```
+
+```ini
+[Unit]
+Description=Billy Web Configuration Server
+After=network.target
+
+[Service]
+WorkingDirectory=/home/pi/billy-b-assistant
+ExecStart=/home/pi/billy-b-assistant/venv/bin/python /home/pi/billy-b-assistant/webconfig/server.py
+Restart=on-failure
+User=pi
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Enable and start:
+
+```bash
+sudo setcap 'cap_net_bind_service=+ep' /usr/bin/python3.11
+sudo systemctl daemon-reload
+sudo systemctl enable billy-webconfig.service
+sudo systemctl start billy-webconfig.service
+```
+
+To view status and logs:
+
+```bash
+sudo systemctl status billy-webconfig.service
+journalctl -u billy-webconfig.service -f
+```
+
+Visit `http://billy.local` anytime to reconfigure Billy!
 
 ---
 
-## 7. Web Configuration Interface
+## I. Run It
 
-Billy includes a lightweight web interface for editing settings, debugging logs, and managing the assistant service without touching the terminal.
+Billy should now boot automatically into standby mode. Press the physical button to start a voice session. Enjoy!
+
+---
+
+## J. Web Configuration Interface
+
+Billy includes a lightweight Web UI for editing settings, debugging logs, and managing the assistant service without touching the terminal.
 
 ### Features
 
@@ -151,148 +368,62 @@ Billy includes a lightweight web interface for editing settings, debugging logs,
 
 ### How to Use
 
-1. Run the web server manually (from the project root):
+See **H. Systemd Services** to automatically start the web server or, to run the web server manually (from the project root):
 
-   ```bash
-   python3 webconfig/server.py
-   ```
+```bash
+python3 webconfig/server.py
+```
 
-2. Enter the your pi's hostname + .local in your browser:
+Enter the your pi's hostname + .local in your browser (replace `billy` if you have set a custom hostname):
 
-   ```
-   http://billy.local
-   ```
+```bash
+http://billy.local
+```
 
-   (Replace `billy` if you have set a custom Pi's hostname)
+### Example `.env` File
 
----
+This file is used to configure your environment, including the [OpenAI API key](https://platform.openai.com/api-keys) and (optional) mqtt settings. It can also be used to overwrite some of the default config settings (like the voice of billy) that you can find in `config.py`.
 
-### Run the Web UI as a Systemd Service
+Note that you **must** establish billing for your API account with an available credit. In the [billing panel](https://platform.openai.com/account/billing/overview), add a payment method (under Payment Methods). After adding a payment method, add credits to your organization by clicking 'Buy credits'. You will see an API error: `The model gpt-4o-mini-realtime-preview does not exist or you do not have access to it.` otherwise.
 
-If you want the web interface to always be available:
-
-1. copy the service file from the repository to the :
-
-   ```bash
-   cp setup/system/billy-webconfig.service /etc/systemd/system/billy-webconfig.service
-   ```
-
-2. Adjust the username / paths if needed:
-
-   ```bash
-   nano /etc/systemd/system/billy-webconfig.service
-   ```
-
-3. Enable and start:
-
-   ```bash
-   sudo setcap 'cap_net_bind_service=+ep' /usr/bin/python3.11
-   sudo systemctl daemon-reload
-   sudo systemctl enable billy-webconfig
-   sudo systemctl start billy-webconfig
-   ```
-
-4. Visit `http://billy.local` anytime to reconfigure Billy!
-
-## 8. Create your `.env` file
-
-When first running the project, it will create a `.env` file in the root of the `billy-b-assistant` folder by copying `.env.example` to `.env` 
-
-This file is used to configure your environment, including the [OpenAI API key](https://platform.openai.com/api-keys) and (optional) mqtt settings. 
-This file can also be used to overwrite some of the default config settings (like the voice of billy) that you can find in config.py.
-
-Updates to the settings via the Web UI will also be saved here.  
-(The DEBUG_MODE_* settings are not exposed in the UI)
-
-### Example `.env` file
-
-```env
-OPENAI_API_KEY=sk-proj-....
+```ini
+OPENAI_API_KEY=<sk-proj-....>
+VOICE=ash
 
 MQTT_HOST=homeassistant.local
 MQTT_PORT=1883
 MQTT_USERNAME=billy
-MQTT_PASSWORD=password
+MQTT_PASSWORD=<password>
 
-## optional overwrites
+## Optional overwrites
 MIC_TIMEOUT_SECONDS=5
 SILENCE_THRESHOLD=900
 
 DEBUG_MODE=true
 DEBUG_MODE_INCLUDE_DELTA=false
+
+ALLOW_UPDATE_PERSONALITY_INI=true
 ```
 
-### Explanation of fields
+**OPENAI_API_KEY**: (Required) get it from <https://platform.openai.com/api-keys>  
+**VOICE**: The OpenAI voice model to use (`onyx`, `shimmer`, `nova`, `echo`, `fable`, `alloy`, or `ballad`, `ash` is default)  
+**MQTT_\***: (Optional) used if you want to integrate Billy with Home Assistant or another MQTT broker  
+**MIC_TIMEOUT_SECONDS**: How long Billy should wait after your last mic activity before ending input  
+**SILENCE_THRESHOLD**: Audio threshold (RMS) for what counts as mic input;lower this value if Billy interrupts you too quickly, set higher if Billy doesn't respond (because he thinks you're still talking)  
+**DEBUG_MODE**: Print debug information such as OpenAI responses to the output stream  
+**DEBUG_MODE_INCLUDE_DELTA**: Also print voice and speech delta data, which can get very noisy  
+**ALLOW_UPDATE_PERSONALITY_INI**: If true, personality updates asked for by the user will be written and committed to the personality file. If false, changes to personality parameters will only affect the current running process (`true` is default)
 
-- `OPENAI_API_KEY`: (Required) get it from https://platform.openai.com/api-keys
-- `VOICE`: The OpenAI voice model to use (`onyx`, `shimmer`, `nova`, `echo`, `fable`, `alloy`, or `ballad`)
-- `MQTT_*`: (Optional) used if you want to integrate Billy with Home Assistant or another MQTT broker
-- `MIC_TIMEOUT_SECONDS`: How long Billy should wait after your last mic activity before ending input
-- `SILENCE_THRESHOLD`: Audio threshold (RMS) for what counts as mic input
-  - lower this value if Billy interrupts you too quickly
-  - higher if Billy doesn't respond (because he thinks you're still talking)
-- `DEBUG_MODE`: Print debug information such as OpenAI responses to the output stream.
-- `DEBUG_MODE_INCLUDE_DELTA`: Also print voice and speech delta data, which can get very noisy.
-- `ALLOW_UPDATE_PERSONALITY_INI`: If true, personality updates asked for by the user will be written and committed to the personality file. If false, changes to personality will only affect the current running process.
----
+### Example `persona.ini` File
 
-## 9. Systemd Service (for auto-boot)
-
-To run Billy as a background service at boot, create `/etc/systemd/system/billy.service`:
-
-```bash
-sudo nano /etc/systemd/system/billy.service
-```
-
-```ini
-[Unit]
-Description=Billy Bass Assistant
-After=network.target sound.target
-
-[Service]
-WorkingDirectory=/home/billy/billy-b-assistant
-ExecStart=/usr/bin/python3 /home/billy/billy-b-assistant/main.py
-Restart=always
-User=billy
-Environment=PYTHONUNBUFFERED=1
-
-[Install]
-WantedBy=multi-user.target
-```
-
-\* Assuming 'billy' is the raspberry pi username
-
-Then run: 
-```
-sudo systemctl daemon-reexec
-sudo systemctl enable billy.service
-sudo systemctl start billy.service
-```
-
-To view logs:
-```
-journalctl -u billy.service -f
-```
-
----
-
-## 10. Run It!
-
-Billy should now boot automatically into standby mode. Press the physical button to start a voice session. Enjoy!
-
----
-
-## 11. (Optional) Configure Persona (via web UI or in `persona.ini`)
-
-The `persona.ini` file controls Billy's **personality**, **backstory**, and **additional instructions**.
-This file will also be created on first run. You can edit this file manually, via the Web UI,  or change the personality trait values during a voice session using commands like:
+The `persona.ini` file controls Billy's **personality**, **backstory**, and **additional instructions**. You can edit this file manually, or change the personality trait values during a voice session using commands like:
 
 - “What is your humor setting?”
 - “Set sarcasm to 80%”
 
 These commands trigger a function call that will automatically update this file on disk.
 
-### [PERSONALITY]
+#### [PERSONALITY]
 
 These traits influence how Billy talks, jokes, and responds. Each is a percentage value from 0 to 100. Higher values amplify the trait:
 
@@ -312,7 +443,7 @@ formality = 0
 
 You can make Billy more sarcastic, verbose, formal or warmer by increasing those values.
 
-### [BACKSTORY]
+#### [BACKSTORY]
 
 This section defines Billy's fictional origin story and sense of identity:
 
@@ -329,8 +460,7 @@ Billy's responses can reference this lore, like being from the Thames or having 
 
 If you prompt him with questions like “Where are you from?” or “How did you get so clever?” he may respond with these facts.
 
-
-### [META]
+#### [META]
 
 These are high-level behavioral instructions passed into the AI system. You can edit them for major tone shifts.
 
@@ -343,15 +473,15 @@ You can tweak this to reflect a different vibe: poetic, mystical, overly formal,
 
 ---
 
-## 12. (Optional) Wake-up Sounds and Custom Songs
+## K. (Optional) Wake-up Sounds and Custom Songs
 
 ### Wake-up Sounds
 
 Billy plays a short randomized wake-up clip before every voice session when the button is pressed.
-These audio files live in the folder:
-`./sounds/wake-up/` 
+These audio files live in the folder `./sounds/wake-up/`.
 
-If you'd like to generate your own wake-up sounds, adjust the lines in the `CLIPS` object and then run the script 
+If you'd like to generate your own wake-up sounds, adjust the lines in the `CLIPS` object and then run the script:
+
 ```bash
 cd ./sounds
 nano generate_clips.py
@@ -362,7 +492,7 @@ python3 generate_clips.py
 
 Billy supports a "song mode" where he performs coordinated audio + motion playback using a structured folder:
 
-```
+```bash
 ./sounds/songs/your_song_name/
 ├── full.wav      # Main audio (played to speakers)
 ├── vocals.wav    # Audio used to flap the mouth (lip sync)
@@ -372,15 +502,19 @@ Billy supports a "song mode" where he performs coordinated audio + motion playba
 
 To add a song:
 
-1. Split your desired song (with an ai tool like https://vocalremover.org/) into separate stems for vocal, music and drums.
-2. Create a new subfolder inside `./sounds/songs/` with your song name 
+1. Split your desired song (with an ai tool like [Vocal Remover and Isolation](https://vocalremover.org/)) into separate stems for vocal, music and drums.
+
+2. Create a new subfolder inside `./sounds/songs/` with your song name
+
 3. Include at minimum:
-    - `full.wav` the song to play
-    - `vocals.wav` the isolated vocals or melody track
-    - `drums.wav` a beat track used for tail flapping
+
+- `full.wav` the song to play
+- `vocals.wav` the isolated vocals or melody track
+- `drums.wav` a beat track used for tail flapping
+
 4. (Optional) Create a `metadata.txt` to fine-tune movement timing.
 
-#### metadata.txt Format
+#### `metadata.txt` Format
 
 ```ini
 gain=1.0
@@ -391,13 +525,13 @@ half_tempo_tail_flap=false
 head_moves=4.0:1,8.0:0,12.0:1
 ```
 
-- `gain`: multiplier for audio intensity
-- `bpm`: tempo used to synchronize timing
-- `tail_threshold`: RMS threshold for tail movement (increase/decrease value when tail flaps too little/much)
-- `compensate_tail`: offset in beats to compensate tail latency
-- `half_tempo_tail_flap`: if true, flaps tail on every 2nd beat
-- `head_moves`: comma-separated list of `beat:duration` values  
-  → At beat `2`, move head for `2.0s`, at `29.5`, move for `2.0s`, etc.
+**gain**: multiplier for audio intensity  
+**bpm**: tempo used to synchronize timing  
+**tail_threshold**: RMS threshold for tail movement (increase/decrease value when tail flaps too little/much)  
+**compensate_tail**: offset in beats to compensate tail latency  
+**half_tempo_tail_flap**: if true, flaps tail on every 2nd beat  
+**head_moves**: comma-separated list of `beat:duration` values  
+  → At beat `2`, move head for `2.0s`, at `29.5`, move for `2.0s`, etc.  
 
 #### Triggering a Song in Conversation
 
@@ -410,10 +544,9 @@ If the folder exists it will play the contents with full animation.
 
 ---
 
-## 13. (Optional) 🏠 Home Assistant Integration (via web UI or in `.env`)
+## L. (Optional) 🏠 Home Assistant Integration
 
-Billy B-Assistant can send smart home commands to your **Home Assistant** instance using its [Conversation API](https://developers.home-assistant.io/docs/api/rest/#post-apiconversationprocess). 
-This lets you say things to Billy like:
+Billy B-Assistant can send smart home commands to your **Home Assistant** instance using its [Conversation API](https://developers.home-assistant.io/docs/api/rest/#post-apiconversationprocess). This lets you say things to Billy like:
 
 - “Turn off the lights in the living room.”
 - “Set the toilet light to red.”
@@ -430,14 +563,18 @@ Billy will forward your command to Home Assistant and speak back the response.
 ### Setup
 
 1. **Generate a Long-Lived Access Token**  
-   In Home Assistant, go to **Profile → Long-Lived Access Tokens → Create Token**  
-   Name it something like `billy-assistant` and copy the token.
+   - In Home Assistant, go to **Profile → Long-Lived Access Tokens → Create Token**  
+   - Name it something like `billy-assistant` and copy the token.
 
-2. **Add these values in the Web UI or directly to your `.env`**:
-   ```env
-   HA_URL=http://homeassistant.local:8123
-   HA_TOKEN=your_long_lived_token
-   HA_LANG=en
+2. Configure using the Web UI or add these values to your `.env`:
+
+    ```ini
+    HA_URL=http://homeassistant.local:8123
+    HA_TOKEN=<your_long_lived_token>
+    HA_LANG=en
+    ```
+
+    You can specify **HA_LANG** in the `.env` to match your spoken language (e.g., `nl` for Dutch or `en` for English). Mismatched language settings may cause parsing errors or incorrect target resolution.
 
 ### How It Works
 
@@ -450,45 +587,52 @@ Behind the scenes:
 - HA processes it as a natural language query
 - Billy extracts the response (`speech.plain.speech`), interprets it and speaks his response out loud
 
-### Language Support
-
-You can specify `HA_LANG` in the `.env` to match your spoken language (e.g., `nl` for Dutch or `en` for English).  
-Mismatched language settings may cause parsing errors or incorrect target resolution.
-
 ### Tips
 
 - Use clear and specific commands for best results
 - Make sure the target rooms/devices are defined in HA
 - Alias your entities in Home Assistant for better voice matching
 
-## Known Issues
+---
+
+# Known Issues
 
 - Restarting the mic input stream after interruption sometimes doesn't work.
 
-## Future Ideas
+---
+
+# Future Ideas
 
 Here are some ideas that I have for features in upcoming releases:
+
 - Work in Progress: **Install script / easier software updates**
 - **Local TTS and STT fallback**
 - **Local custom wake-word detection**
 
-## Support the Project
+---
+
+# Support the Project
+
 Billy B-Assistant is a project built and maintained for fun and experimentation, free for **personal** and **educational** use.
 See [LICENSE](./LICENSE) for full details.
 
 If you enjoy your Billy and want to help improve it, here’s how you can support:
 
-### Contributing Code
+## Contributing Code
 
 Pull requests are welcome! If you have an idea for a new feature, bug fix, or improvement:
 
-1. Fork the repository
-2. Create a new branch (`git checkout -b my-feature`)
-3. Make your changes
-4. Commit and push (`git commit -am "Add feature" && git push origin my-feature`)
-5. Open a pull request on GitHub
+  1. Fork the repository
 
-### ☕ Buy Me a Coffee
+  2. Create a new branch (`git checkout -b my-feature`)
+
+  3. Make your changes
+
+  4. Commit and push (`git commit -am "Add feature" && git push origin my-feature`)
+
+  5. Open a pull request on GitHub
+
+## ☕ Buy Me a Coffee
 
 Enjoying the project? Feel free to leave a small tip, totally optional, but much appreciated!
 

--- a/core/audio.py
+++ b/core/audio.py
@@ -57,10 +57,11 @@ def detect_devices(debug=False):
 
     devices = sd.query_devices()
 
+    print("🔢 Enumerating audio devices...")
     for i, d in enumerate(devices):
         if debug:
             print(
-                f"{i}: {d['name']} (inputs: {d['max_input_channels']}, outputs: {d['max_output_channels']})"
+                f"  {i}: {d['name']} (inputs: {d['max_input_channels']}, outputs: {d['max_output_channels']})"
             )
 
         if MIC_DEVICE_INDEX is None and d['max_input_channels'] > 0:
@@ -70,6 +71,7 @@ def detect_devices(debug=False):
                 or not MIC_PREFERENCE
             ):
                 MIC_DEVICE_INDEX = i
+                print(f"✔ Input device index {i} selected.")
 
             MIC_RATE = int(d['default_samplerate'])
             MIC_CHANNELS = d['max_input_channels']
@@ -82,6 +84,7 @@ def detect_devices(debug=False):
                 or not SPEAKER_PREFERENCE
             ):
                 OUTPUT_DEVICE_INDEX = i
+                print(f"✔ Output device index {i} selected.")
 
             OUTPUT_RATE = int(d['default_samplerate'])
             OUTPUT_CHANNELS = d['max_output_channels']
@@ -128,7 +131,8 @@ def playback_worker(chunk_ms):
                         head_out = True
                         head_move_active = True
                         head_move_end_time = now + move_duration
-                        print(f"🐟 Head move started for {move_duration:.2f} seconds")
+                        print(
+                            f"🐟 Head move started for {move_duration:.2f} seconds")
 
                 if item is None:
                     print("🧵 Received stop signal, cleaning up.")
@@ -183,14 +187,15 @@ def playback_worker(chunk_ms):
                         mono = np.frombuffer(chunk, dtype=np.int16)
                         chunk_len = int(24000 * chunk_ms / 1000)
                         for i in range(0, len(mono), chunk_len):
-                            sub = mono[i : i + chunk_len]
+                            sub = mono[i: i + chunk_len]
                             if len(sub) == 0:
                                 continue
                             flap_from_pcm_chunk(sub, chunk_ms=chunk_ms)
                             resampled = resample(
                                 sub, int(len(sub) * 48000 / 24000)
                             ).astype(np.int16)
-                            stereo = np.repeat(resampled[:, np.newaxis], 2, axis=1)
+                            stereo = np.repeat(
+                                resampled[:, np.newaxis], 2, axis=1)
                             stereo = np.clip(
                                 stereo * PLAYBACK_VOLUME, -32768, 32767
                             ).astype(np.int16)
@@ -200,14 +205,15 @@ def playback_worker(chunk_ms):
                             if interlude_counter >= interlude_target:
                                 interlude()
                                 interlude_counter = 0
-                                interlude_target = random.randint(80000, 160000)
+                                interlude_target = random.randint(
+                                    80000, 160000)
 
                 else:
                     chunk = item
                     mono = np.frombuffer(chunk, dtype=np.int16)
                     chunk_len = int(24000 * chunk_ms / 1000)
                     for i in range(0, len(mono), chunk_len):
-                        sub = mono[i : i + chunk_len]
+                        sub = mono[i: i + chunk_len]
                         if len(sub) == 0:
                             continue
                         flap_from_pcm_chunk(sub, chunk_ms=chunk_ms)
@@ -437,7 +443,8 @@ async def play_song(song_name):
     ensure_playback_worker_started(CHUNK_MS)
 
     mqtt_publish("billy/state", "playing_song")
-    print(f"\n🎧 Playing {song_name} with mouth (vocals) and tail (drums) flaps")
+    print(
+        f"\n🎧 Playing {song_name} with mouth (vocals) and tail (drums) flaps")
 
     try:
         with contextlib.ExitStack() as stack:
@@ -493,7 +500,8 @@ async def play_song(song_name):
                 samples_drums = np.clip(samples_drums * GAIN, -32768, 32767).astype(
                     np.int16
                 )
-                rms_drums = np.sqrt(np.mean(samples_drums.astype(np.float32) ** 2))
+                rms_drums = np.sqrt(
+                    np.mean(samples_drums.astype(np.float32) ** 2))
 
                 # --- Enqueue combined chunk
                 audio.playback_queue.put((

--- a/core/movements.py
+++ b/core/movements.py
@@ -20,14 +20,14 @@ h = lgpio.gpiochip_open(0)
 FREQ = 10000  # PWM frequency
 
 # Pin mapping
-MOUTH_IN1 = 12  # PWM0
-MOUTH_IN2 = 5
-HEAD_IN1 = 13  # PWM1
-HEAD_IN2 = 6
+MOUTH_IN1 = 12  # PWM0_CHAN0, pin 32
+MOUTH_IN2 = 5   # pin 29
+HEAD_IN1 = 13   # PWM0_CHAN1, pin 33
+HEAD_IN2 = 6    # pin 31
 
-if USE_THIRD_MOTOR:
-    TAIL_IN1 = 18  # PWM2 (Pi 5) or any free GPIO
-    TAIL_IN2 = 19
+if USE_THIRD_MOTOR:  # Note: more than three hardware PWM channels is only a Pi5 feature!
+    TAIL_IN1 = 19    # PWM0_CHAN3, pin 35
+    TAIL_IN2 = 26    # pin 37
 
 # Claim GPIOs
 motor_pins = [MOUTH_IN1, MOUTH_IN2, HEAD_IN1, HEAD_IN2]
@@ -133,7 +133,8 @@ def flap_from_pcm_chunk(
     dyn_range = peak / (rms + 1e-5)
 
     # Flap speed and duration scaling
-    speed = int(np.clip(np.interp(normalized, [0.005, 0.15], [25, 100]), 25, 100))
+    speed = int(
+        np.clip(np.interp(normalized, [0.005, 0.15], [25, 100]), 25, 100))
     duration_ms = np.interp(normalized, [0.005, 0.15], [15, 70])
 
     duration_ms = np.clip(duration_ms, 15, chunk_ms)

--- a/docs/BUILDME.md
+++ b/docs/BUILDME.md
@@ -1,26 +1,28 @@
-# Billy Bass Assistant – Build Instructions
+# Billy B-Assistant – Build Instructions
 
-This guide explains how to physically build and wire your Raspberry Pi–powered **Billy Bass Assistant**
+This guide explains how to physically build and wire your Raspberry Pi–powered **Billy Bass Assistant**.
 
 ---
 
 ## Parts List
-> ✅ [3D-printed custom backplate](https://makerworld.com/en/models/1457024-ai-fish-billy-big-mouth-bass-backplate#profileId-1518677)
 
-| Part                                         | EU                                                                                                                                          | Global                                                             |
-|----------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------|
-| Big Mouth Billy Bass                         | [Amazon](https://amzn.eu/d/gzyNRsg)                                                                                                         |                                                                    |
-| Raspberry Pi 5 (4gb RAM or more recommended) | [Kiwi Electronics](https://www.kiwi-electronics.com/nl/raspberry-pi-5-computers-accessoires-415/raspberry-pi-5-4gb-11579 )                  |                                                                    |
-| Raspberry Pi Power Supply 45W                | [Kiwi Electronics](https://www.kiwi-electronics.com/nl/raspberry-pi-45w-usb-c-power-supply-wit-eu-20344 )                                   |                                                                    |
-| MicroSD card ( for Raspberry OS Lite)        | [Kiwi Electronics](https://www.kiwi-electronics.com/nl/transcend-64gb-microsd-met-adapter-uhs-i-u3-a2-ultra-performance-160-80-mb-s-11632 ) |                                                                    |
-| Raspberry Pi Active Cooler                   | [Kiwi Electronics](https://www.kiwi-electronics.com/nl/raspberry-pi-active-cooler-11585 )                                                   |                                                                    |
-| 1x USB Speaker                               | [Amazon](https://amzn.eu/d/2yklfno)                                                                                                         | [AliExpress](https://nl.aliexpress.com/item/1005007168026736.html) |
-| 1x USB Microphone                            | [Amazon](https://amzn.eu/d/7Y9GhoL)                                                                                                         | [AliExpress](https://nl.aliexpress.com/item/1005007211513791.html) |
-| 1x L298N Motor Driver                        | [Amazon](https://amzn.eu/d/g9yBNVg)                                                                                                         | [AliExpress](https://nl.aliexpress.com/item/1005006890733953.html) |
-| Jumper Wires / Dupont Cables                 | [Amazon](https://amzn.eu/d/i4kyXG2)                                                                                                         | [AliExpress](https://nl.aliexpress.com/item/1005003641187997.html) |
-| *JST 2.54 4 pin connector (female)           | [Amazon](https://amzn.eu/d/cDqHgNv)                                                                                                         | [AliExpress](https://nl.aliexpress.com/item/1005007460897865.html) |
+- [3D-printed custom backplate](https://makerworld.com/en/models/1457024-ai-fish-billy-big-mouth-bass-backplate#profileId-1518677)
+- [Alternative 3D-printed parts (for Christmas edition)](https://www.thingiverse.com/thing:7096350)
 
-*recommended to be able to easily (un)plug the motor cables
+| Part                                         | Source |
+|----------------------------------------------|--------|
+| Big Mouth Billy Bass                         | [Amazon NL](https://amzn.eu/d/gzyNRsg) |
+| Raspberry Pi 5 (4gb RAM or more recommended) | [Kiwi Electronics](https://www.kiwi-electronics.com/nl/raspberry-pi-5-computers-accessoires-415/raspberry-pi-5-4gb-11579) |
+| Raspberry Pi Power Supply 45W                | [Kiwi Electronics](https://www.kiwi-electronics.com/nl/raspberry-pi-45w-usb-c-power-supply-wit-eu-20344) |
+| MicroSD card (for Raspberry OS Lite)         | [Kiwi Electronics](https://www.kiwi-electronics.com/nl/transcend-64gb-microsd-met-adapter-uhs-i-u3-a2-ultra-performance-160-80-mb-s-11632 ) |
+| Raspberry Pi Active Cooler                   | [Kiwi Electronics](https://www.kiwi-electronics.com/nl/raspberry-pi-active-cooler-11585) |
+| 1x USB Speaker                               | [Amazon NL](https://amzn.eu/d/2yklfno), [Amazon US](https://www.amazon.com/dp/B075M7FHM1), [AliExpress](https://aliexpress.com/item/1005007168026736.html) |
+| 1x USB Microphone                            | [Amazon NL](https://amzn.eu/d/7Y9GhoL), [Amazon US](https://www.amazon.com/dp/B08M37224H), [AliExpress](https://aliexpress.com/item/1005007211513791.html) |
+| 1x L298N Motor Driver                        | [Amazon NL](https://amzn.eu/d/g9yBNVg), [Amazon US](https://www.amazon.com/dp/B0B82GZVT5), [AliExpress](https://aliexpress.com/item/1005006890733953.html) |
+| Jumper Wires / Dupont Cables                 | [Amazon NL](https://amzn.eu/d/i4kyXG2), [AliExpress](https://aliexpress.com/item/1005003641187997.html) |
+| JST 2.54 4 pin connector (female) \*         | [Amazon NL](https://amzn.eu/d/cDqHgNv), [AliExpress](https://aliexpress.com/item/1005007460897865.html) |
+
+\* Recommended to be able to easily (un)plug the motor cables.
 
 ## Tools List
 
@@ -35,31 +37,32 @@ This guide explains how to physically build and wire your Raspberry Pi–powered
 
 ---
 
-## 1. Gut the Fish
+## A. Gut the Fish
 
 ![Original Wiring](./images/original_wiring.jpeg)
-- Remove the 6 philips screws in the back of the Billy and remove the original backplate. Save the screws for re-assembly later.
-- Unplug all the electronic plugs, only keep the two motors + the jst plug (with Red Black White Orange wires) and the push button. Remove the tweeter (?) (disc shaped with blue wires) and the light/motion sensor (yellow wires)
-- In the spot where the sensor was, the microphone will be placed so cut away the plastic extrusion until it is (somewhat) flush to the rest of the housing.
-  - I used the flush cutter to cut away chunks of plastic and used the pliers to twist & turn to remove the plastic.
 
-  
-## 2. Wiring Instructions
+> Note that different editions of the Billy might have different hardware arrangements and wiring colors.
+
+- Remove the 6 philips screws in the back of the Billy and remove the original backplate. Save the screws for re-assembly later
+- Unplug all the electronic plugs, only keep the two motors + the JST plug (with Red Black White Orange wires) and the push button. Remove the piezoelectric speaker (disc shaped with blue wires) and the light/motion sensor (yellow wires)
+- In the spot where the sensor was, the microphone will be placed so cut away the plastic extrusion until it is (somewhat) flush to the rest of the housing (I used the flush cutter to cut away chunks of plastic and used the pliers to twist & turn to remove the plastic)
+
+## B. Wiring Instructions
 
 ### From Motor to Motor Driver
 
 Solder either (90 degree corner) header pins on INT1-INT4 and + - to be able to use intact female to female jumper wires.
 or cut the jumper wires keeping the female plug intact and solder the bare wire ends onto the board.
 
-Solder the other end of the jst plug onto the board. The order is important.
-In my case the colors of the plug don't match the colors of the original motor cables (see photo below), 
-therefore included the JST wire color column is included. 
+Solder the other end of the JST plug onto the board. The order is important.
+In my case the colors of the plug don't match the colors of the original motor cables (see photo below),
+therefore included the JST wire color column is included.
 
-If you don't use the jst connector and solder the motor wires directly 
-to the driver board or if you have a jst connector with different wire colors / order, 
+If you don't use the JST connector and solder the motor wires directly
+to the driver board or if you have a JST connector with different wire colors / order,
 focus only on the motor wire color and the corresponding pin on the driver board.
 
-The table below is considered with motor driver board oriented with the Motor B and Motor A labels in the 
+The table below is considered with motor driver board oriented with the Motor B and Motor A labels in the
 bottom left corner of the board. The 1-4 positions are counted from left to right.
 
 | Motor Driver Pin (position) | Wire Color JST | Motor Wire Color |
@@ -72,53 +75,56 @@ bottom left corner of the board. The 1-4 positions are counted from left to righ
 ![Motor to Driver](./images/motor_driver.jpeg)
 ![JST connector](./images/jst_connector.jpeg)
 
-
 ### From Motor Driver to Raspberry Pi (GPIO Pinout)
 
-Using distinct jumper wire colors is recommended for easier identification. 
+Using distinct jumper wire colors is recommended for easier identification.
 
-| Component | GPIO Pin number (physical pin)   | Function                           |
-|-----------|----------------------------------|------------------------------------|
-| Motor IN1 | GPIO 13 (pin 33)                 | Head & tail direction/speed (PWM1) |
-| Motor IN2 | GPIO 6  (pin 31)                 | Head &tail on/off                  |
-| Motor IN1 | GPIO 12 (pin 32)                 | Mouth direction/speed (PWM0)       |
-| Motor IN2 | GPIO 5  (pin 29)                 | Mouth on/off                       |
-| Motor +   | 5v pwr  (pin 5)                  | Power to motor driver              |
-| Motor -   | Ground  (pin 6)                  |                                    |
-| Button    | GPIO 27 (pin 13) & GND (pin 14)  | Trigger voice session              |
+| Component | GPIO Pin number (physical pin)   | Function                                         |
+|-------------------------|----------------------------------|------------------------------------|
+| Controller 1, Motor IN1 | GPIO 13 (pin 33)                 | Head & tail direction/speed (PWM1) |
+| Controller 1, Motor IN2 | GPIO 6  (pin 31)                 | Head & tail on/off                 |
+| Controller 1, Motor IN3 | GPIO 12 (pin 32)                 | Mouth direction/speed (PWM0)       |
+| Controller 1, Motor IN4 | GPIO 5  (pin 29)                 | Mouth on/off                       |
+| Controller 2, Motor IN1 | GPIO 19 (pin 35)                 | Tail direction/speed (PWM2)        |
+| Controller 2, Motor IN2 | GPIO 26 (pin 37)                 | Tail on/off                        |
+| Motor +                 | 5v pwr  (pin 4)                  | Power to motor driver              |
+| Motor -                 | Ground  (pin 4)                  |                                    |
+| Button                  | GPIO 27 (pin 13) & GND (pin 14)  | Trigger voice session              |
 
 ![GPIO pins](./images/gpio-pins.png)
 ![Assembly overview 1](./images/assembly_1.jpeg)
 ![Assembly overview 2](./images/assembly_2.jpeg)
+
 ### Speaker and mic
 
-Using an existing usb speaker and usb microphone is the easiest route. 
+Using an existing USB speaker and USB microphone is the easiest route.
 
 Remove the Philips screw in the back of the speaker to be able to separate the front and the back of the speaker housing.
-Take note / a picture of the wiring of the usb cable at the audio board (probably from left to right: Black, Green, White and Red) and cut the cable at ~ 15cm to reduce the unneeded cable length. 
-Remove the wire from the back of the housing and resolder the 4 usb cables accordingly.
-We only need one speaker but in the backplate there are two speaker spots: 
+Take note / a picture of the wiring of the USB cable at the audio board (probably from left to right: Black, Green, White and Red) and cut the cable at ~ 15cm to reduce the unneeded cable length.
+Remove the wire from the back of the housing and resolder the 4 USB cables accordingly.
+We only need one speaker but in the backplate there are two speaker spots:
+
 - one facing to the side of the housing, a couple holes need to be drilled in the original housing to create a 'speaker grill' for sound to pass through. This spot is recommended since it will place the speaker closest to the mouth of Billy.
 - one facing downwards (like the original placement). This is for future-proofing in case of a different method of mounting (standalone / not flush against the wall)
 
 Place the speaker in the speaker holder and place it onto the backplate.
 
-Remove the top part of the microphone housing and place the microphone component itself in the 3d printed holder and place it on the backplate.
+Remove the top part of the microphone housing and place the microphone component itself in the 3D printed holder and place it on the backplate.
 These holders should be a snug fit. If not; use a bit of glue to secure it.
 
 ![Assembly overview 3](./images/assembly_3.jpeg)
-In the picture above both speaker spots are used. 
+In the picture above both speaker spots are used.
 The 'downward' facing speaker is only recommended when there is a bit of space for the sound between the wall and billy.
 The microphone is not shown in this photo since my initial idea was to glue it in place in the original housing.
 Afterwards I added the mic holder for easier assembly.
 
-### Assemble
+## C. Assemble
 
-> Before connecting the motors and powering up the raspberry pi it is recommended to have completed at least step **3. GPIO Voltage Configuration (Motor Safety)** of the [README.md](./../README.md)
+> Before connecting the motors and powering up the Raspberry Pi it is recommended to have completed at least step **C. GPIO Voltage Configuration (Motor Safety)** of the [README.md](./../README.md)
 
-Once all the components are placed into the backplate (and everything is connected) the backplate can be mounted onto the original housing. 
-Route the usb c cable through the existing hole on the top and first attach only 2 of the 6 screws.
-Continue with the software installation if you haven't done so already and do a first test run of Billy. 
+Once all the components are placed into the backplate (and everything is connected) the backplate can be mounted onto the original housing.
+Route the USB-C cable through the existing hole on the top and first attach only 2 of the 6 screws.
+Continue with the software installation if you haven't done so already and do a first test run of Billy.
 If everything works as expected screw in the remaining screws.
 
 ![Assembly overview 4](./images/assembly_4.jpeg)

--- a/setup/system/billy-webconfig.service
+++ b/setup/system/billy-webconfig.service
@@ -3,10 +3,10 @@ Description=Billy Web Configuration Server
 After=network.target
 
 [Service]
-WorkingDirectory=/home/billy/billy-b-assistant
-ExecStart=/usr/bin/python3 /home/billy/billy-b-assistant/webconfig/server.py
+WorkingDirectory=/home/pi/billy-b-assistant
+ExecStart=/home/pi/billy-b-assistant/venv/bin/python /home/pi/billy-b-assistant/webconfig/server.py
 Restart=on-failure
-User=billy
+User=pi
 
 [Install]
 WantedBy=multi-user.target

--- a/setup/system/billy-wifi-check.service
+++ b/setup/system/billy-wifi-check.service
@@ -5,12 +5,12 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-ExecStartPre=/bin/sleep 15
-ExecStart=/home/billy/billy-b-assistant/setup/wifi_check.sh
-WorkingDirectory=/home/billy/billy-b-assistant/setup
-Restart=on-failure
 User=root
 Environment="PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+WorkingDirectory=/home/pi/billy-b-assistant/setup
+ExecStartPre=/bin/sleep 15
+ExecStart=/home/pi/billy-b-assistant/setup/wifi_check.sh
+Restart=on-failure
 StandardOutput="journal"
 StandardError="journal"
 

--- a/setup/system/billy-wifi-setup.service
+++ b/setup/system/billy-wifi-setup.service
@@ -4,10 +4,10 @@ After=network.target
 
 [Service]
 User=root
-WorkingDirectory=/home/billy/billy-b-assistant/setup
-ExecStart=/usr/bin/python3 /home/billy/billy-b-assistant/setup/wifi_setup.py
-Restart=on-failure
 Environment="PYTHONBUFFERED=1"
+WorkingDirectory=/home/pi/billy-b-assistant/setup
+ExecStart=/home/pi/billy-b-assistant/venv/bin/python /home/pi/billy-b-assistant/setup/wifi_setup.py
+Restart=on-failure
 StandardOutput=journal
 StandardError=journal
 

--- a/setup/system/billy.service
+++ b/setup/system/billy.service
@@ -3,11 +3,11 @@ Description=Billy Bass Assistant
 After=network.target sound.target
 
 [Service]
-WorkingDirectory=/home/billy/billy-b-assistant
-ExecStart=/usr/bin/python3 /home/billy/billy-b-assistant/main.py
-Restart=always
-User=billy
+User=pi
 Environment=PYTHONUNBUFFERED=1
+WorkingDirectory=/home/pi/billy-b-assistant
+ExecStart=/home/pi/billy-b-assistant/venv/bin/python /home/pi/billy-b-assistant/main.py
+Restart=always
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
* Cleaned up some style, using Visual Code formatter.
* Moved 3rd motor GPIO pins to GPIO 16 and 26 to allow connections to group closer together on the Pi header and allow use of 7x2 and 6x2 header blocks, to reduce (re)assembly errors. Updated documentation to match.
* Added some additional debug output to `audio.py` for audio device enumeration.
* Fixed startup for server.py that was preventing starting on version check with a development branch.
* Updated documentation:
  - Made style consistent throughout.
  - Expanded Pi Imager instructions.
  - Reverted `billy` username to `pi` to match imager default (instructions and installer don't support the `billy` user currently)
  - Added section on creating Python Virtual environment (to address externally-managed-environment that is issued when trying to install packages using pip). Updated systemd scripts to match.
  - Added note about ChatGPT credit related to #3 and #15.
  - Added links to US-based Amazon hardware examples
  - Fixed GPIO power connection pin numbers.
  - Added section on configuring and testing audio.
  - Added link to alternative 3D models for mounting hardware.