### PR TITLE
Add mockfish mode: enables GPIO mocking for development without hardware 

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,6 +614,15 @@ Please check the [existing issues](https://github.com/Thokoop/billy-b-assistant/
 
 ---
 
+# MockFish Mode 
+
+MockFish is a development and testing mode designed for this project, eliminating 
+the need for a physical Billy Bass fish. Motor movements are simulated, and the 
+local device's microphone and speakers are utilized. This mode is particularly useful
+for testing new GUI features, integrating new AI providers, and evaluating personality behaviors.
+
+---
+
 # Support the Project
 
 Billy B-Assistant is a project built and maintained for fun and experimentation, free for **personal** and **educational** use.

--- a/core/config.py
+++ b/core/config.py
@@ -281,6 +281,7 @@ FLASK_PORT = int(os.getenv("FLASK_PORT", "80"))
 SHOW_SUPPORT = os.getenv("SHOW_SUPPORT", True)
 FORCE_PASS_CHANGE = os.getenv("FORCE_PASS_CHANGE", "false").lower() == "true"
 SHOW_RC_VERSIONS = os.getenv("SHOW_RC_VERSIONS", "False")
+MOCKFISH = os.getenv("MOCKFISH", "false").lower() == "true"
 
 # === User Profile Config ===
 DEFAULT_USER = os.getenv("DEFAULT_USER", "guest").strip()

--- a/core/movements.py
+++ b/core/movements.py
@@ -5,11 +5,51 @@ import threading
 import time
 from threading import Lock, Thread
 
-import lgpio
 import numpy as np
 
-from .config import BILLY_PINS, is_classic_billy
+from .config import BILLY_PINS, is_classic_billy, MOCKFISH
 from .logger import logger
+
+try:
+    import lgpio
+    lgpio_available = True
+except ImportError:
+    lgpio_available = False
+
+if MOCKFISH or not lgpio_available:
+    # Mock lgpio for development or when not available
+    class MockLgpio:
+        error = Exception
+
+        @staticmethod
+        def gpiochip_open(chip):
+            return "mock_handle"
+
+        @staticmethod
+        def gpio_claim_output(h, pin):
+            pass
+
+        @staticmethod
+        def gpio_write(h, pin, value):
+            pass
+
+        @staticmethod
+        def tx_pwm(h, pin, freq, duty):
+            pass
+
+        @staticmethod
+        def gpio_free(h, pin):
+            pass
+
+        @staticmethod
+        def gpiochip_close(h):
+            pass
+
+    lgpio = MockLgpio
+    if MOCKFISH:
+        logger.info("Mockfish: GPIO mocked for development", "🐟")
+    elif not lgpio_available:
+        logger.info("lgpio not available: GPIO mocked", "🐟")
 
 
 # === Configuration ===

--- a/main.py
+++ b/main.py
@@ -60,9 +60,6 @@ def signal_handler(sig, frame):
     sys.exit(0)
 
 
-main_event_loop = asyncio.get_event_loop()
-
-
 def main():
     signal.signal(signal.SIGINT, signal_handler)
     signal.signal(signal.SIGTERM, signal_handler)


### PR DESCRIPTION
This enables the entire program to be tested on my MacBook Pro m4 without a connected fish.