### PR TITLE
Fixed issue #59 - installing swig

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ Install required system packages:
 
 ```bash
 sudo apt update
-sudo apt install -y python3-pip libportaudio2 ffmpeg liblgpio-dev liblgpio1
+sudo apt install -y python3-pip libportaudio2 ffmpeg liblgpio-dev liblgpio1 swig
 ```
 
 Create Python virtual environment:


### PR DESCRIPTION
 When users are installing python requirements, ``lgpio`` will fail. Installing the ``swig`` library fixes this issue.
 
 example fail:
 
 ```bash
 Building wheels for collected packages: lgpio
  Building wheel for lgpio (pyproject.toml) ... error
  error: subprocess-exited-with-error
  
  × Building wheel for lgpio (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [8 lines of output]
      running bdist_wheel
      running build
      running build_py
      running build_ext
      building '_lgpio' extension
      swigging lgpio.i to lgpio_wrap.c
      swig -python -o lgpio_wrap.c lgpio.i
      error: command 'swig' failed: No such file or directory
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for lgpio
Failed to build lgpio
ERROR: Failed to build installable wheels for some pyproject.toml based projects (lgpio)
 
 ```